### PR TITLE
URI exception error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+## Experimental
+This repository's objective is to "play" with the capabilities of a plugin by developing sample features in order to better understand how to program a dicoogle plugin.
+
 Dicoogle Plugin - Sample 
 ========================
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-## Experimental
-This repository's objective is to "play" with the capabilities of a plugin by developing sample features in order to better understand how to program a dicoogle plugin.
-
 Dicoogle Plugin - Sample 
 ========================
 

--- a/src/main/java/pt/ieeta/dicoogle/plugin/sample/query/SampleQueryPlugin.java
+++ b/src/main/java/pt/ieeta/dicoogle/plugin/sample/query/SampleQueryPlugin.java
@@ -62,7 +62,8 @@ public class SampleQueryPlugin implements QueryInterface {
         map.put("StudyDate", "20150120");
         map.put("SeriesDate", "20150120");
 
-        SearchResult r = new SearchResult(URI.create("file:" + File.separatorChar + UUID.randomUUID().toString()), 1, map);
+        // TODO check if this "///" works on linux
+        SearchResult r = new SearchResult(URI.create("file:///" + UUID.randomUUID().toString()), 1, map);
 
         return r;
     }


### PR DESCRIPTION
Running this plugin sample on windows, an URI format error is thrown.

Changing the File.separatorChar to "///" fixed this error on windows.

I wasn't, however, able to test this change on linux.